### PR TITLE
Support multiple connection

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ export async function createServer(options: {
   command: string;
   bufferSize?: number;
   port: number;
-}) {
+}): Promise<{ stop: () => void }> {
   const { prefix, command, bufferSize = 300, port } = options;
   
   // Create Express app
@@ -258,7 +258,7 @@ export async function createServer(options: {
   
   // Return a stop function
   return {
-    stop: () => {
+    stop: (): void => {
       commandRunner.stop();
       server_instance.close();
       console.log(`[${prefix}] MCP server stopped`);


### PR DESCRIPTION
If I have two Cursor open, or reopen Cursor, expo server (mcp-command-proxy server) will crash.

```
[expo] SSE endpoint connected
[expo] Message received: {
  method: 'initialize',
  params: {
    protocolVersion: '2025-06-18',
    capabilities: {
      tools: true,
      prompts: false,
      resources: false,
      logging: false,
      roots: [Object]
    },
    clientInfo: { name: 'cursor-vscode', version: '1.0.0' }
  },
  jsonrpc: '2.0',
  id: 1
}
[expo] SSE endpoint connected
node:_http_server:351
    throw new ERR_HTTP_HEADERS_SENT('write');
          ^

Error [ERR_HTTP_HEADERS_SENT]: Cannot write headers after they are sent to the client
    at ServerResponse.writeHead (node:_http_server:351:11)
    at SSEServerTransport.start (file:///Users/user/Projects/app-dev/node_modules/@modelcontextprotocol/sdk/dist/esm/server/sse.js:56:18)
    at Server.connect (file:///Users/user/Projects/app-dev/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/protocol.js:95:31)
    at McpServer.connect (file:///Users/user/Projects/app-dev/node_modules/@modelcontextprotocol/sdk/dist/esm/server/mcp.js:30:34)
    at file:///Users/user/Projects/app-dev/node_modules/mcp-command-proxy/dist/index.js:134:22
    at Layer.handle [as handle_request] (/Users/user/Projects/app-dev/node_modules/express/lib/router/layer.js:95:5)
    at next (/Users/user/Projects/app-dev/node_modules/express/lib/router/route.js:149:13)
    at Route.dispatch (/Users/user/Projects/app-dev/node_modules/express/lib/router/route.js:119:3)
    at Layer.handle [as handle_request] (/Users/user/Projects/app-dev/node_modules/express/lib/router/layer.js:95:5)
    at /Users/user/Projects/app-dev/node_modules/express/lib/router/index.js:284:15 {
  code: 'ERR_HTTP_HEADERS_SENT'
}

Node.js v22.16.0
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

This update allow multiple connection and handle close.